### PR TITLE
chore: replace old GitHub Pages domain with new custom domain

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 URL: https://github.com/IndrajeetPatil/intro-to-snapshot-testing/,
-    https://indrajeetpatil.github.io/intro-to-snapshot-testing/
+    https://www.indrapatil.com/intro-to-snapshot-testing/
 BugReports: https://github.com/IndrajeetPatil/intro-to-snapshot-testing/issues
 Depends:
     downlit,

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ tests are valuable in testing:
 - entire files
 
 Slides can be seen here:
-<https://indrajeetpatil.github.io/intro-to-snapshot-testing/>
+<https://www.indrapatil.com/intro-to-snapshot-testing/>
 
 Feedback and suggestions are welcome!
 

--- a/index.qmd
+++ b/index.qmd
@@ -22,7 +22,7 @@ lang: "en"
 dir: "ltr"
 image: "media/social-media-card.png"
 image-alt: "Preview image for presentation about snapshot testing in R"
-canonical-url: "https://indrajeetpatil.github.io/intro-to-snapshot-testing/"
+canonical-url: "https://www.indrapatil.com/intro-to-snapshot-testing/"
 ---
 
 ## Introduction to Snapshot Testing in R {style="margin-top: 1em;"}
@@ -1688,7 +1688,7 @@ And Happy Snapshotting! 😊
 
 ::: {style="text-align: center; font-size: 0.7em;"}
 
-Check out my other [slide decks](https://indrajeetpatil.github.io/presentations/) on software development best practices
+Check out my other [slide decks](https://www.indrapatil.com/presentations/) on software development best practices
 
 :::
 

--- a/meta-tags.html
+++ b/meta-tags.html
@@ -23,11 +23,11 @@
 />
 <meta
   property="og:image"
-  content="https://indrajeetpatil.github.io/intro-to-snapshot-testing/media/social-media-card.png"
+  content="https://www.indrapatil.com/intro-to-snapshot-testing/media/social-media-card.png"
 />
 <meta
   property="og:url"
-  content="https://indrajeetpatil.github.io/intro-to-snapshot-testing/"
+  content="https://www.indrapatil.com/intro-to-snapshot-testing/"
 />
 <meta property="og:type" content="website" />
 <meta property="og:site_name" content="Introduction to Snapshot Testing in R" />
@@ -44,6 +44,6 @@
 />
 <meta
   name="twitter:image"
-  content="https://indrajeetpatil.github.io/intro-to-snapshot-testing/media/social-media-card.png"
+  content="https://www.indrapatil.com/intro-to-snapshot-testing/media/social-media-card.png"
 />
 <meta name="twitter:creator" content="@patilindrajeets" />


### PR DESCRIPTION
## Summary

This PR updates all references from the old GitHub Pages domain to the new custom domain:

- **Old**: `https://indrajeetpatil.github.io/`
- **New**: `https://www.indrapatil.com/`

This is part of a bulk domain migration across all repositories.