### PR TITLE
chore: unify Google Analytics Measurement ID

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -9,7 +9,7 @@ format:
     link-external-newwindow: true
     code-link: true
     include-in-header: meta-tags.html
-    google-analytics: "G-Z140SPPYBN"
+    google-analytics: "G-3BQ49J7KYH"
 execute:
   echo: true
 keywords: ["snapshot testing", "testthat", "shinytest2", "vdiffr", "r programming"]

--- a/meta-tags.html
+++ b/meta-tags.html
@@ -1,7 +1,7 @@
 <!-- Google tag (gtag.js) -->
 <script
   async
-  src="https://www.googletagmanager.com/gtag/js?id=G-Z140SPPYBN"
+  src="https://www.googletagmanager.com/gtag/js?id=G-3BQ49J7KYH"
 ></script>
 <script>
   window.dataLayer = window.dataLayer || [];
@@ -10,7 +10,7 @@
   }
   gtag("js", new Date());
 
-  gtag("config", "G-Z140SPPYBN");
+  gtag("config", "G-3BQ49J7KYH");
 </script>
 
 <meta


### PR DESCRIPTION
Uses the root domain's Google Analytics Measurement ID for consolidated tracking across all presentations, as per best practices.